### PR TITLE
FIX-#1957: 'default_to_pandas' of unsupported operations added

### DIFF
--- a/modin/experimental/backends/omnisci/default_methods_builder.py
+++ b/modin/experimental/backends/omnisci/default_methods_builder.py
@@ -1,0 +1,120 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+from modin.backends.pandas.query_compiler import PandasQueryCompiler
+
+import pandas
+import numpy as np
+import re
+
+from pandas.core.dtypes.common import is_scalar
+
+
+def DFAlgNotSupported(fn_name):
+    def fn(*args, **kwargs):
+        raise NotImplementedError(
+            "{} is not yet suported in DFAlgQueryCompiler".format(fn_name)
+        )
+
+    return fn
+
+
+def _property_wrapper_builder(fn_name):
+    def property_wrapper(df):
+        return getattr(df, fn_name)
+
+    return property_wrapper
+
+
+def _series_wrapper_builder(fn):
+    def series_wrapper(df, *args, **kwargs):
+        result = fn(df.squeeze(axis=1), *args, **kwargs)
+        if is_scalar(result):
+            result = pandas.Series(result)
+        return result
+
+    return series_wrapper
+
+
+def _build_default_method(obj, fn_name):
+    fn = getattr(obj, fn_name)
+    assert callable(fn) or type(fn) == property
+
+    if type(fn) == property:
+        fn = _property_wrapper_builder(fn_name)
+
+    if obj == pandas.Series:
+        fn = _series_wrapper_builder(fn)
+
+    def wrapper(self, *args, **kwargs):
+        return self.default_to_pandas(fn, *args, **kwargs)
+
+    # setting proper function name that will be printed in default to pandas warning
+    wrapper.__name__ = f"pandas.{obj.__name__}.{fn_name}"
+    return wrapper
+
+
+def _build_default_groupby(name):
+    return DFAlgNotSupported(name)
+
+
+def _pick_group(name):
+    for group_name, picker in _group_pickers.items():
+        if picker(name):
+            return group_name
+    return None
+
+
+def add_defaults(cls):
+    all_methods, implemented_methods = map(
+        lambda x: frozenset(x.__dict__.keys()), [PandasQueryCompiler, cls]
+    )
+    not_implemented = all_methods.difference(implemented_methods)
+
+    replacable = {key: [] for key in _group_pickers.keys()}
+
+    for name in not_implemented:
+        group_name = _pick_group(name)
+        if group_name is not None:
+            replacable[group_name].append(name)
+
+    for group_name, methods in replacable.items():
+        builder = _default_builders[group_name]
+        for method in methods:
+            setattr(cls, method, builder(method))
+
+    not_supported = not_implemented.difference(
+        np.concatenate(list(replacable.values()))
+    )
+    for name in not_supported:
+        setattr(cls, name, DFAlgNotSupported(name))
+
+    cls.__abstractmethods__ = frozenset(cls.__abstractmethods__).difference(
+        cls.__dict__.keys()
+    )
+
+    return cls
+
+
+_group_pickers = {
+    "dataframe": lambda name: hasattr(pandas.DataFrame, name),
+    "series": lambda name: hasattr(pandas.Series, name)
+    and not hasattr(pandas.DataFrame, name),
+    "groupby": lambda name: re.match(r"groupby_.*", name) is not None,
+}
+
+_default_builders = {
+    "dataframe": lambda name: _build_default_method(pandas.DataFrame, name),
+    "series": lambda name: _build_default_method(pandas.Series, name),
+    "groupby": _build_default_groupby,
+}

--- a/modin/experimental/backends/omnisci/query_compiler.py
+++ b/modin/experimental/backends/omnisci/query_compiler.py
@@ -50,12 +50,6 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
 
         return wrapper
 
-    def __getattr__(self, key):
-        if key in dir(PandasQueryCompiler):
-            return self._default_to_pandas_builder(key)
-        else:
-            raise AttributeError(key)
-
     def to_pandas(self):
         return self._modin_frame.to_pandas()
 

--- a/modin/experimental/backends/omnisci/query_compiler.py
+++ b/modin/experimental/backends/omnisci/query_compiler.py
@@ -32,24 +32,6 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
         self._modin_frame = frame
         self._shape_hint = shape_hint
 
-    def _default_to_pandas_df(self, __method_name__, *args, **kwargs):
-        return self.default_to_pandas(
-            getattr(pandas.DataFrame, __method_name__), *args, **kwargs
-        )
-
-    def _default_to_pandas_ser(self, __method_name__, *args, **kwargs):
-        return self.default_to_pandas(
-            getattr(pandas.Series, __method_name__), *args, **kwargs
-        )
-
-    def _default_to_pandas_builder(self, key):
-        def wrapper(*args, **kwargs):
-            return self.default_to_pandas(
-                getattr(pandas.DataFrame, key), *args, **kwargs
-            )
-
-        return wrapper
-
     def to_pandas(self):
         return self._modin_frame.to_pandas()
 

--- a/modin/experimental/backends/omnisci/query_compiler.py
+++ b/modin/experimental/backends/omnisci/query_compiler.py
@@ -218,7 +218,15 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
         return self._modin_frame.index
 
     def _set_index(self, index):
-        self._modin_frame.index = index
+        # ModinFrame._set_index is not supported yet
+        # self._modin_frame.index = index
+        def set_index(df):
+            df.index = index
+            return df
+
+        new_qc = self.default_to_pandas(set_index)
+        self._modin_frame = new_qc._modin_frame
+        self._shape_hint = new_qc._shape_hint
 
     def _get_columns(self):
         return self._modin_frame.columns

--- a/modin/experimental/engines/omnisci_on_ray/frame/data.py
+++ b/modin/experimental/engines/omnisci_on_ray/frame/data.py
@@ -42,6 +42,7 @@ from .expr import (
 from collections import OrderedDict
 
 import numpy as np
+import re
 import pyarrow
 
 
@@ -349,6 +350,7 @@ class OmnisciOnRayFrame(BasePandasFrame):
         )
 
     def astype(self, col_dtypes, **kwargs):
+        # breakpoint()
         columns = col_dtypes.keys()
         new_dtypes = self.dtypes.copy()
         for column in columns:
@@ -1023,7 +1025,7 @@ class OmnisciOnRayFrame(BasePandasFrame):
         return [self._index_name(n) for n in cols]
 
     def _index_name(self, col):
-        if col.startswith("__index__"):
+        if col.startswith("__index__") or re.match(r"__index\d*__", col) is not None:
             return None
         return col
 
@@ -1033,7 +1035,7 @@ class OmnisciOnRayFrame(BasePandasFrame):
         new_columns = df.columns
         # If there is non-trivial index, we put it into columns.
         # That's what we usually have for arrow tables and execution
-        # result. Unnamed index is renamed to __index__. Also all
+        # result. Unnamed index is renamed to __index{i}__. Also all
         # columns get 'F_' prefix to handle names unsupported in
         # OmniSci.
         if cls._is_trivial_index(df.index):
@@ -1042,7 +1044,10 @@ class OmnisciOnRayFrame(BasePandasFrame):
             orig_index_names = df.index.names
             orig_df = df
 
-            index_cols = ["__index__" if n is None else n for n in df.index.names]
+            index_cols = [
+                f"__index{i}__" if n is None else n
+                for i, n in enumerate(df.index.names)
+            ]
             df.index.names = index_cols
             df = df.reset_index()
 


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [ ] passes `flake8 modin`
- [ ] passes `black --check modin`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves modin-project#1957 <!-- issue must be created for each patch -->
- [ ] tests added and passing
