### PR TITLE
support simple bool index (filter)

### DIFF
--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -13,6 +13,8 @@
 
 import numpy as np
 import pandas
+from pandas.core.common import is_bool_indexer
+from pandas.core.indexing import check_bool_indexer
 from pandas.core.dtypes.common import (
     is_list_like,
     is_numeric_dtype,
@@ -31,6 +33,8 @@ from modin.data_management.functions import (
     BinaryFunction,
     GroupbyReduceFunction,
 )
+
+import warnings
 
 
 def _get_axis(axis):
@@ -1702,6 +1706,43 @@ class PandasQueryCompiler(BaseQueryCompiler):
     # END Map across rows/columns
 
     # __getitem__ methods
+    def getitem_array(self, key):
+        # TODO: dont convert to pandas for array indexing
+        if isinstance(key, type(self)):
+            key = key.to_pandas()
+        if is_bool_indexer(key):
+            if isinstance(key, pandas.Series) and not key.index.equals(self.index):
+                warnings.warn(
+                    "Boolean Series key will be reindexed to match DataFrame index.",
+                    PendingDeprecationWarning,
+                    stacklevel=3,
+                )
+            elif len(key) != len(self.index):
+                raise ValueError(
+                    "Item wrong length {} instead of {}.".format(
+                        len(key), len(self.index)
+                    )
+                )
+            key = check_bool_indexer(self.index, key)
+            # We convert to a RangeIndex because getitem_row_array is expecting a list
+            # of indices, and RangeIndex will give us the exact indices of each boolean
+            # requested.
+            key = pandas.RangeIndex(len(self.index))[key]
+            if len(key):
+                return self.getitem_row_array(key)
+            else:
+                return self.from_pandas(
+                    pandas.DataFrame(columns=self.columns), type(self._modin_frame)
+                )
+        else:
+            if any(k not in self.columns for k in key):
+                raise KeyError(
+                    "{} not index".format(
+                        str([k for k in key if k not in self.columns]).replace(",", "")
+                    )
+                )
+            return self.getitem_column_array(key)
+
     def getitem_column_array(self, key, numeric=False):
         """Get column data for target labels.
 

--- a/modin/experimental/engines/omnisci_on_ray/frame/calcite_builder.py
+++ b/modin/experimental/engines/omnisci_on_ray/frame/calcite_builder.py
@@ -40,6 +40,7 @@ from .df_algebra import (
     JoinNode,
     UnionNode,
     SortNode,
+    FilterNode,
 )
 
 from collections import abc
@@ -294,6 +295,8 @@ class CalciteBuilder:
                 self._process_union(op)
             elif isinstance(op, SortNode):
                 self._process_sort(op)
+            elif isinstance(op, FilterNode):
+                self._process_filter(op)
             else:
                 raise NotImplementedError(
                     f"CalciteBuilder doesn't support {type(op).__name__}"
@@ -462,3 +465,7 @@ class CalciteBuilder:
                 CalciteCollation(self._ref_idx(frame, col), ascending, nulls)
             )
         self._push(CalciteSortNode(collations))
+
+    def _process_filter(self, op):
+        condition = self._translate(op.condition)
+        self._push(CalciteFilterNode(condition))

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -12,7 +12,7 @@
 # governing permissions and limitations under the License.
 
 import pandas
-from pandas.core.common import apply_if_callable, is_bool_indexer
+from pandas.core.common import apply_if_callable
 from pandas.core.dtypes.common import (
     infer_dtype_from_object,
     is_dict_like,
@@ -20,7 +20,6 @@ from pandas.core.dtypes.common import (
     is_numeric_dtype,
 )
 from pandas.core.indexes.api import ensure_index_from_sequences
-from pandas.core.indexing import check_bool_indexer
 from pandas.util._validators import validate_bool_kwarg
 from pandas.io.formats.printing import pprint_thing
 
@@ -2441,8 +2440,12 @@ class DataFrame(BasePandasDataset):
                 return self._getitem_column(key)
         except (KeyError, ValueError, TypeError):
             pass
-        if isinstance(key, (Series, np.ndarray, pandas.Index, list)):
-            return self._getitem_array(key)
+        if isinstance(key, Series):
+            return DataFrame(
+                query_compiler=self._query_compiler.getitem_array(key._query_compiler)
+            )
+        if isinstance(key, (np.ndarray, pandas.Index, list)):
+            return DataFrame(query_compiler=self._query_compiler.getitem_array(key))
         elif isinstance(key, DataFrame):
             return self.where(key)
         elif is_mi_columns:
@@ -2461,45 +2464,6 @@ class DataFrame(BasePandasDataset):
             s._parent = self
             s._parent_axis = 1
         return s
-
-    def _getitem_array(self, key):
-        # TODO: dont convert to pandas for array indexing
-        if isinstance(key, Series):
-            key = key._to_pandas()
-        if is_bool_indexer(key):
-            if isinstance(key, pandas.Series) and not key.index.equals(self.index):
-                warnings.warn(
-                    "Boolean Series key will be reindexed to match DataFrame index.",
-                    PendingDeprecationWarning,
-                    stacklevel=3,
-                )
-            elif len(key) != len(self.index):
-                raise ValueError(
-                    "Item wrong length {} instead of {}.".format(
-                        len(key), len(self.index)
-                    )
-                )
-            key = check_bool_indexer(self.index, key)
-            # We convert to a RangeIndex because getitem_row_array is expecting a list
-            # of indices, and RangeIndex will give us the exact indices of each boolean
-            # requested.
-            key = pandas.RangeIndex(len(self.index))[key]
-            if len(key):
-                return DataFrame(
-                    query_compiler=self._query_compiler.getitem_row_array(key)
-                )
-            else:
-                return DataFrame(columns=self.columns)
-        else:
-            if any(k not in self.columns for k in key):
-                raise KeyError(
-                    "{} not index".format(
-                        str([k for k in key if k not in self.columns]).replace(",", "")
-                    )
-                )
-            return DataFrame(
-                query_compiler=self._query_compiler.getitem_column_array(key)
-            )
 
     def __getattr__(self, key):
         """After regular attribute access, looks up the name in the columns


### PR DESCRIPTION
Census benchmark uses `query` method to filter rows. We can use indexing to do the same, it is simpler to support than `query`. We have to move `getitem_array` from `DataFrame` to `QueryCompiler` to support that in OmniSci.