### PR TITLE
Add a switch between FullAxis and MapReduce groupby

### DIFF
--- a/modin/core/io/file_dispatcher.py
+++ b/modin/core/io/file_dispatcher.py
@@ -164,8 +164,13 @@ class FileDispatcher(ClassLogger):
         # unnecessary check for our case; hack for now (#4793)
         # however we can return dtypes explicitly as lengths and widths;
         # in that way we save time that could have been spent deserializing an entire dataframe;
-        if False and hasattr(query_compiler, "dtypes") and any(
-            isinstance(t, kernel_lib.CategoricalDtype) for t in query_compiler.dtypes
+        if (
+            False
+            and hasattr(query_compiler, "dtypes")
+            and any(
+                isinstance(t, kernel_lib.CategoricalDtype)
+                for t in query_compiler.dtypes
+            )
         ):
             dtypes = query_compiler.dtypes
             return query_compiler.astype(

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -2785,7 +2785,8 @@ class PandasQueryCompiler(BaseQueryCompiler):
         how="axis_wise",
         drop=False,
     ):
-        if isinstance(agg_func, dict) and all(
+        force_full_axis = agg_kwargs.pop("force_full_axis", False)
+        if not force_full_axis and isinstance(agg_func, dict) and all(
             is_reduce_function(x) for x in agg_func.values()
         ):
             return self._groupby_dict_reduce(

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -2786,8 +2786,10 @@ class PandasQueryCompiler(BaseQueryCompiler):
         drop=False,
     ):
         force_full_axis = agg_kwargs.pop("force_full_axis", False)
-        if not force_full_axis and isinstance(agg_func, dict) and all(
-            is_reduce_function(x) for x in agg_func.values()
+        if (
+            not force_full_axis
+            and isinstance(agg_func, dict)
+            and all(is_reduce_function(x) for x in agg_func.values())
         ):
             return self._groupby_dict_reduce(
                 by, agg_func, axis, groupby_kwargs, agg_args, agg_kwargs, drop

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -16,28 +16,36 @@ import warnings
 
 orig_copy = pandas.MultiIndex.copy
 
-def new_copy(self, names=None, dtype=None, levels=None, codes=None, deep=False, name=None):
+
+def new_copy(
+    self, names=None, dtype=None, levels=None, codes=None, deep=False, name=None
+):
     result = orig_copy(self, names, dtype, levels, codes, deep, name)
     if not deep and levels is None and codes is None:
         result._id = self._id
     return result
+
 
 pandas.MultiIndex.copy = new_copy
 
 
 orig_index_new = pandas.core.indexes.base._new_Index
 
+
 def index_newer(cls, d):
     import pandas
+
     if issubclass(cls, pandas.MultiIndex):
         d["verify_integrity"] = False
 
     return orig_index_new(cls, d)
 
+
 pandas.core.indexes.base._new_Index = index_newer
 
 
 orig_mi_append = pandas.MultiIndex.append
+
 
 def new_append(self, other):
     import pandas
@@ -48,15 +56,24 @@ def new_append(self, other):
 
     if all(isinstance(obj, pandas.MultiIndex) for obj in other):
         if all(obj.nlevels == self.nlevels for obj in other):
-            if all(all(pandas.core.dtypes.missing.array_equivalent(slev, olev) for slev, olev in zip(self._levels, obj._levels)) for obj in other):
+            if all(
+                all(
+                    pandas.core.dtypes.missing.array_equivalent(slev, olev)
+                    for slev, olev in zip(self._levels, obj._levels)
+                )
+                for obj in other
+            ):
                 objs = [self] + other
                 new_codes = []
                 for i in range(self.nlevels):
                     lev_codes = np.concatenate([obj.codes[i] for obj in objs])
                     new_codes.append(lev_codes)
-                mi = pandas.MultiIndex(codes=new_codes, levels=self.levels, names=self.names)
+                mi = pandas.MultiIndex(
+                    codes=new_codes, levels=self.levels, names=self.names
+                )
                 return mi
     return orig_mi_append(self, other)
+
 
 pandas.MultiIndex.append = new_append
 

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -489,7 +489,7 @@ class DataFrameGroupBy(ClassLogger):
             numeric_only=True,
         )
 
-    def aggregate(self, func=None, *args, **kwargs):
+    def aggregate(self, func=None, force_full_axis=False, *args, **kwargs):
         if self._axis != 0:
             # This is not implemented in pandas,
             # so we throw a different message
@@ -574,7 +574,7 @@ class DataFrameGroupBy(ClassLogger):
             numeric_only=False,
             agg_func=func,
             agg_args=args,
-            agg_kwargs=kwargs,
+            agg_kwargs={**kwargs, "force_full_axis": force_full_axis},
             how="axis_wise",
         )
 


### PR DESCRIPTION
Signed-off-by: proxodilka <zeeron209@gmail.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

The PR adds a bool parameter called `force_full_axis` to the [`DataFrameGroupBy.aggregate`](https://github.com/intel-ai/modin/blob/fb5d0df26169314f878fe2e60ff88b9d6df1e28e/modin/pandas/groupby.py#L492) that allows you to choose between MapReduce and column FullAxis implementations of dictionary `groupby.agg`.

### How to use
```python
grp = df.groupby("col1")
grp.agg(price_mean=("price", "mean"), price_sum=("price", "sum")) # This groupby goes through MapReduce pattern
grp.agg(price_mean=("price", "mean"), price_sum=("price", "sum"), force_full_axis=True) # This groupby goes through FullAxis pattern
```

### Why?
Using the present implementation of MapReduce pattern in Modin isn't always beneficial for GroupBy. In cases, where the amount of unique groups is high and comparable to the length of the dataframe itself, it appears that with MapReduce approach we waste time on a spare Map phase. Check the following example:
```python
>>> df
  by_col  agg_col
0      a        1
1      b        2       <--- partition1
2      c        3
---------------------------
3      d        2
4      e        5       <--- partition2
5      f       10

>>> # Map phase: each partition performs groupby-aggregation independently
>>> part1_res = partition1.groupby("by_col").sum()
        agg_col
by_col
a             1
b             2
c             3
>>> part2_res = partition2.groupby("by_col").sum()
        agg_col
by_col
d             2
e             5
f            10
>>> # Reduce phase: all row partitions are concatenated together to sum the results from all partitions
>>> reduction_partition = pandas.concat([part1_res, part2_res])
        agg_col
by_col
a             1
b             2
c             3
d             2
e             5
f            10
>>> result = reduction_partition.groupby("by_col").sum()
```
As you can see, in the reduction phase we ended up with exactly the same frame as the source one, meaning that the whole Map phase was useless. Ideally, the Map phase should reduce the shape of the frame, so in the Reduction phase we would met a significantly smaller frame than the source one. In cases when the Map phase does not reduce the frame's shape, we can omit it and go right to the Reduction phase. This skip can be implemented as falling to the FullAxis implementation of the groupby aggregation (qc.groupby_agg).

### Should we use it in RecSys?

Inspecting a quarter of the `part-00015.parquet` data (a quarter is ~800k rows) shows that in all of the performed GroupBys the number of unique groups is very close to the number of rows in the frame itself, meaning that we <i>should</i> benefit from using full-axis approach. 
![Figure_412221](https://user-images.githubusercontent.com/62142979/183937950-eefa3e7b-9c7e-450e-8067-bce4e1a0d34c.png)
However, it's still questionable whether this distribution is maintained over the whole dataset.

- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [ ] passes `flake8 modin`
- [ ] passes `black --check modin`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #? <!-- issue must be created for each patch -->
- [ ] tests added and passing
